### PR TITLE
Allow Bluetooth LE scanning on KitKat

### DIFF
--- a/nitrogen6x/required_hardware.xml
+++ b/nitrogen6x/required_hardware.xml
@@ -24,6 +24,7 @@
     <feature name="android.hardware.location.network" />
     <feature name="android.hardware.wifi" />
     <feature name="android.hardware.bluetooth" />
+    <feature name="android.hardware.bluetooth_le" />
     <feature name="android.hardware.faketouch" />
     <feature name="android.hardware.touchscreen" />
     <feature name="android.hardware.touchscreen.multitouch" />


### PR DESCRIPTION
Without this startLEScan will fail
