### PR TITLE
Remove obsolete mount option nomblk_io_submit

### DIFF
--- a/cad/fstab.freescale
+++ b/cad/fstab.freescale
@@ -16,6 +16,6 @@
 $BD1    /boot     vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD2    /recovery vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD5    /system   ext4    ro                                                                               wait
-$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,nomblk_io_submit,noauto_da_alloc,errors=panic    wait
-$BD6    /cache    ext4    nosuid,nodev,nomblk_io_submit                                                    wait
+$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,noauto_da_alloc,errors=panic                     wait
+$BD6    /cache    ext4    nosuid,nodev                                                                     wait
 $BD7    /device   ext4    ro,nosuid,nodev                                                                  wait

--- a/ls/fstab.freescale
+++ b/ls/fstab.freescale
@@ -9,6 +9,6 @@
 $BD1    /boot     vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD2    /recovery vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD5    /system   ext4    ro                                                                               wait
-$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,nomblk_io_submit,noauto_da_alloc,errors=panic    wait
-$BD6    /cache    ext4    nosuid,nodev,nomblk_io_submit                                                    wait
+$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,noauto_da_alloc,errors=panic                     wait
+$BD6    /cache    ext4    nosuid,nodev                                                                     wait
 $BD7    /device   ext4    ro,nosuid,nodev                                                                  wait

--- a/med/fstab.freescale
+++ b/med/fstab.freescale
@@ -16,6 +16,6 @@
 $BD1    /boot     vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD2    /recovery vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD5    /system   ext4    ro                                                                               wait
-$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,nomblk_io_submit,noauto_da_alloc,errors=panic    wait
-$BD6    /cache    ext4    nosuid,nodev,nomblk_io_submit                                                    wait
+$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,noauto_da_alloc,errors=panic                     wait
+$BD6    /cache    ext4    nosuid,nodev                                                                     wait
 $BD7    /device   ext4    ro,nosuid,nodev                                                                  wait

--- a/nit6xlite/fstab.freescale
+++ b/nit6xlite/fstab.freescale
@@ -8,6 +8,6 @@
 $BD1    /boot     vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD2    /recovery vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD5    /system   ext4    ro                                                                               wait
-$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,nomblk_io_submit,noauto_da_alloc,errors=panic    wait
-$BD6    /cache    ext4    nosuid,nodev,nomblk_io_submit                                                    wait
+$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,noauto_da_alloc,errors=panic                     wait
+$BD6    /cache    ext4    nosuid,nodev                                                                     wait
 $BD7    /device   ext4    ro,nosuid,nodev                                                                  wait

--- a/nitrogen6x/fstab.freescale
+++ b/nitrogen6x/fstab.freescale
@@ -16,6 +16,6 @@
 $BD1    /boot     vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD2    /recovery vfat    noatime,nodiratime,errors=remount-ro                                             wait
 $BD5    /system   ext4    ro                                                                               wait
-$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,nomblk_io_submit,noauto_da_alloc,errors=panic    wait
-$BD6    /cache    ext4    nosuid,nodev,nomblk_io_submit                                                    wait
+$BD4    /data     ext4    nosuid,nodev,nodiratime,noatime,noauto_da_alloc,errors=panic                     wait
+$BD6    /cache    ext4    nosuid,nodev                                                                     wait
 $BD7    /device   ext4    ro,nosuid,nodev                                                                  wait


### PR DESCRIPTION
Remove obsolete mount option nomblk_io_submit to avoid the kernel warning
message:
Ignoring removed nomblk_io_submit option

Signed-off-by: Diego Rondini diego.rondini@kynetics.it
