### PR TITLE
Remove duplicate automatic_brightness config

### DIFF
--- a/cad/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/cad/overlay/frameworks/base/core/res/res/values/config.xml
@@ -69,8 +69,6 @@
         <item>"ethernet,9,9,2,-1,true"</item>
     </string-array>
 
-    <bool name="config_automatic_brightness_available">true</bool>
-
     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
          The N entries of this array define N + 1 zones as follows:
 

--- a/ls/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/ls/overlay/frameworks/base/core/res/res/values/config.xml
@@ -67,8 +67,6 @@
         <item>"bluetooth,7,7,0,-1,true"</item>
     </string-array>
 
-    <bool name="config_automatic_brightness_available">true</bool>
-
     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
          The N entries of this array define N + 1 zones as follows:
 

--- a/med/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/med/overlay/frameworks/base/core/res/res/values/config.xml
@@ -69,8 +69,6 @@
         <item>"ethernet,9,9,2,-1,true"</item>
     </string-array>
 
-    <bool name="config_automatic_brightness_available">true</bool>
-
     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
          The N entries of this array define N + 1 zones as follows:
 

--- a/nit6xlite/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/nit6xlite/overlay/frameworks/base/core/res/res/values/config.xml
@@ -77,8 +77,6 @@
         <item>"ethernet,9,9,2,-1,true"</item>
     </string-array>
 
-    <bool name="config_automatic_brightness_available">true</bool>
-
     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
          The N entries of this array define N + 1 zones as follows:
 

--- a/nitrogen6x/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/nitrogen6x/overlay/frameworks/base/core/res/res/values/config.xml
@@ -77,8 +77,6 @@
         <item>"ethernet,9,9,2,-1,true"</item>
     </string-array>
 
-    <bool name="config_automatic_brightness_available">true</bool>
-
     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
          The N entries of this array define N + 1 zones as follows:
 


### PR DESCRIPTION
Remove duplicate config_automatic_brightness_available definition in
frameworks/base overlay, maintaining previous value (true).

Signed-off-by: Diego Rondini diego.rondini@kynetics.it
