### PR TITLE
Android 9 patches for Nitrogen8M and Nitrogen8M Mini

### DIFF
--- a/imx8m/nitrogen8m/init.rc
+++ b/imx8m/nitrogen8m/init.rc
@@ -107,10 +107,10 @@ on early-boot
     chmod 0755 /sys/kernel/debug/tracing
 
     # Default backlight device
-    setprop hw.backlight.dev "30a00000.mipi_dsi_bridge.0"
+    setprop hw.backlight.dev "backlight-mipi"
     # Chmod/chown FSL specific sys entry
-    chown system system /sys/class/backlight/30a00000.mipi_dsi_bridge.0/brightness
-    chmod 0660 /sys/class/backlight/30a00000.mipi_dsi_bridge.0/brightness
+    chown system system /sys/class/backlight/backlight-mipi/brightness
+    chmod 0660 /sys/class/backlight/backlight-mipi/brightness
 
     # Set light sensor sysfs path and light sensor threshold lux value
     setprop ro.hardware.lightsensor "/sys/class/i2c-dev/i2c-0/device/0-0044/"

--- a/imx8m/nitrogen8m/init.rc
+++ b/imx8m/nitrogen8m/init.rc
@@ -248,6 +248,9 @@ on post-fs
     # This may have been created by the recovery system with the wrong context.
     restorecon /cache/recovery
 
+    # Allow writing to the kernel trace log.
+    chmod 0222 /sys/kernel/debug/tracing/trace_marker
+
 on post-fs-data
     setprop vold.post_fs_data_done 1
 

--- a/imx8m/nitrogen8mm/bootscript.txt
+++ b/imx8m/nitrogen8mm/bootscript.txt
@@ -60,7 +60,6 @@ fi
 if itest.s "x" != "x${cmd_mipi}" ; then
 	run cmd_mipi
 	if itest.s "x" != "x${fb_mipi_name}" ; then
-		primary_display=mxsfb-drm ;
 		tile_support=disable ;
 	fi
 fi
@@ -69,6 +68,7 @@ setenv bootargs $bootargs console=${console},115200 vmalloc=128M consoleblank=0 
 setenv bootargs $bootargs androidboot.hardware=freescale androidboot.soc=${soc}
 setenv bootargs $bootargs firmware_class.path=/vendor/firmware
 setenv bootargs $bootargs androidboot.keystore=software
+setenv bootargs $bootargs androidboot.primary_display=imx-drm
 
 if itest.s "xmmc" == "x$devtype" ; then
 	if itest.s "x0" == "x$devnum" ; then
@@ -87,12 +87,6 @@ if itest.s "x" != "x$selinux" ; then
 	setenv bootargs $bootargs androidboot.selinux=$selinux
 else
 	setenv bootargs $bootargs androidboot.selinux=permissive
-fi
-
-if itest.s "x" != "x${primary_display}" ; then
-	setenv bootargs $bootargs androidboot.primary_display=${primary_display}
-else
-	setenv bootargs $bootargs androidboot.primary_display=imx-drm
 fi
 
 if itest.s "x" != "x${tile_support}" ; then

--- a/imx8m/nitrogen8mm/init.rc
+++ b/imx8m/nitrogen8mm/init.rc
@@ -252,6 +252,9 @@ on post-fs
     # This may have been created by the recovery system with the wrong context.
     restorecon /cache/recovery
 
+    # Allow writing to the kernel trace log.
+    chmod 0222 /sys/kernel/debug/tracing/trace_marker
+
 on post-fs-data
     setprop vold.post_fs_data_done 1
     # create temp node for secure storage proxy

--- a/imx8m/nitrogen8mm/init.rc
+++ b/imx8m/nitrogen8mm/init.rc
@@ -111,10 +111,10 @@ on early-boot
     chmod 0755 /sys/kernel/debug/tracing
 
     # Default backlight device
-    setprop hw.backlight.dev "32e10000.mipi_dsi.0"
+    setprop hw.backlight.dev "backlight-mipi"
     # Chmod/chown FSL specific sys entry
-    chown system system /sys/class/backlight/32e10000.mipi_dsi.0/brightness
-    chmod 0660 /sys/class/backlight/32e10000.mipi_dsi.0/brightness
+    chown system system /sys/class/backlight/backlight-mipi/brightness
+    chmod 0660 /sys/class/backlight/backlight-mipi/brightness
 
     # Set light sensor sysfs path and light sensor threshold lux value
     setprop ro.hardware.lightsensor "/sys/class/i2c-dev/i2c-0/device/0-0044/"


### PR DESCRIPTION
This pull request fixes:

- 8 inches MIPI display resolution on Nitrogen8M Mini
- WebView not working on both Nitrogen8M and Nitrogen8M Mini
- Backlight for MIPI display not working on both Nitrogen8M and Nitrogen8M Mini