### PR TITLE
Changes to support the Access Control board

### DIFF
--- a/common/init.rc
+++ b/common/init.rc
@@ -176,5 +176,11 @@ on post-fs
     # This may have been created by the recovery system with the wrong context.
     restorecon /cache/recovery
 
+    # Wiegand permissions
+    chmod 0666 /sys/kernel/wiegand/hexval
+    chown system system /sys/kernel/wiegand/hexval
+    chmod 0666 /sys/kernel/wiegand/length
+    chown system system /sys/kernel/wiegand/length
+
 on post-fs-data
     setprop vold.post_fs_data_done 1

--- a/nit6xlite/BoardConfig.mk
+++ b/nit6xlite/BoardConfig.mk
@@ -11,7 +11,7 @@ ifeq ($(PREBUILT_FSL_IMX_CODEC),true)
 endif
 
 TARGET_KERNEL_DEFCONF := boundary_android_defconfig
-TARGET_BOARD_DTS_CONFIG := imx6dl:imx6dl-nit6xlite.dtb
+TARGET_BOARD_DTS_CONFIG := imx6dl:imx6dl-nit6xlite.dtb imx6dl:imx6dl-nit6xlite-access.dtb
 
 TARGET_RECOVERY_FSTAB := device/boundary/nit6xlite/fstab.freescale
 

--- a/nit6xlite/BoardConfig.mk
+++ b/nit6xlite/BoardConfig.mk
@@ -69,13 +69,13 @@ WPA_SUPPLICANT_VERSION           := VER_0_8_X
 BOARD_WPA_SUPPLICANT_DRIVER      := NL80211
 BOARD_HOSTAPD_DRIVER             := NL80211
 
-BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_bcmdhd
-BOARD_WLAN_DEVICE                := bcmdhd
-BOARD_HOSTAPD_PRIVATE_LIB        := lib_driver_cmd_bcmdhd
-BOARD_HAVE_BLUETOOTH_BCM         := true
+BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_qcwcn
+BOARD_WLAN_DEVICE                := qcwcn
+BOARD_HOSTAPD_PRIVATE_LIB        := lib_driver_cmd_qcwcn
+BOARD_HAVE_BLUETOOTH_QCOM        := true
+BOARD_SUPPORTS_BLE_VND           := true
 BOARD_VENDOR_KERNEL_MODULES += \
-	$(KERNEL_OUT)/drivers/net/wireless/broadcom/brcm80211/brcmutil/brcmutil.ko \
-	$(KERNEL_OUT)/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko
+	$(TARGET_OUT_INTERMEDIATES)/ETC/qcacld_wlan.ko_intermediates/qcacld_wlan.ko
 
 BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR=device/boundary/nit6xlite/
 

--- a/nit6xlite/bootscript.txt
+++ b/nit6xlite/bootscript.txt
@@ -1,3 +1,6 @@
+setenv board nit6xlite-access
+setenv board_name nit6xlite-access
+
 setenv distro_bootpart 1
 
 setexpr rval *0x020CC068 \& 0x180

--- a/nit6xlite/bootscript.txt
+++ b/nit6xlite/bootscript.txt
@@ -145,6 +145,10 @@ setenv bootargs $bootargs fec.disable_giga=1
 
 if itest.s "x" != "x$wlmac" ; then
 	setenv bootargs $bootargs wlcore.mac=$wlmac
+	setenv bootargs $bootargs androidboot.wlan.mac=$wlmac
+	# create a bt mac address from the wlan one
+	setexpr btmac sub "(..:..:..:).(.*)" "\\1b\\2" ${wlmac}
+	setenv bootargs $bootargs androidboot.btmacaddr=${btmac}
 fi
 
 if itest.s "x" == "x$cma" ; then

--- a/nit6xlite/nit6xlite.mk
+++ b/nit6xlite/nit6xlite.mk
@@ -1,6 +1,7 @@
 -include device/fsl/common/imx_path/ImxPathConfig.mk
 $(call inherit-product, device/fsl/imx6/imx6.mk)
 $(call inherit-product-if-exists,vendor/google/products/gms.mk)
+include device/boundary/nitrogen6x/wifi_config.mk
 
 # Overrides
 PRODUCT_NAME := nit6xlite
@@ -45,6 +46,11 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
 	$(LINUX_FIRMWARE_PATH)/linux-firmware-imx/firmware/vpu/vpu_fw_imx6d.bin:vendor/lib/firmware/vpu/vpu_fw_imx6d.bin \
 	$(LINUX_FIRMWARE_PATH)/linux-firmware-imx/firmware/vpu/vpu_fw_imx6q.bin:vendor/lib/firmware/vpu/vpu_fw_imx6q.bin
+
+# WLAN driver configuration files
+PRODUCT_COPY_FILES += \
+	device/boundary/common/wpa_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/wpa_supplicant_overlay.conf     \
+	device/boundary/common/p2p_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/p2p_supplicant_overlay.conf     \
 
 # Vendor seccomp policy files for media components:
 PRODUCT_COPY_FILES += \
@@ -122,21 +128,28 @@ PRODUCT_PACKAGES += \
 	audio.a2dp.default
 
 # WLAN driver configuration files
-PRODUCT_COPY_FILES += \
-	device/boundary/common/wpa_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/wpa_supplicant_overlay.conf     \
-	device/boundary/common/p2p_supplicant_overlay.conf:$(TARGET_COPY_OUT_VENDOR)/etc/wifi/p2p_supplicant_overlay.conf     \
+PRODUCT_PACKAGES += \
+	android.hardware.bluetooth@1.0-service \
+	qcacld_wlan.ko \
+	bdwlan30.bin \
+	otp30.bin \
+	qca/tfbtfw11.tlv \
+	qca/tfbtnv11.bin \
+	qwlan30.bin \
+	utf30.bin \
+	utfbd30.bin \
+	wlan/cfg.dat \
+	wlan/qcom_cfg.ini
 
 PRODUCT_COPY_FILES += \
-	device/boundary/common/init.bcm.rc:root/init.bt-wlan.rc \
-	device/boundary/nit6xlite/bt_vendor.conf:vendor/bluetooth/bt_vendor.conf \
-	device/boundary/brcm/bcm4330.hcd:vendor/firmware/bcm4330.hcd \
-	device/boundary/brcm/brcmfmac4330-sdio.bin:vendor/firmware/brcm/brcmfmac4330-sdio.bin \
-	device/boundary/brcm/brcmfmac4330-sdio.txt:vendor/firmware/brcm/brcmfmac4330-sdio.txt
+	device/boundary/common/init.qca.rc:root/init.bt-wlan.rc
+
+# Specify which rfkill node to use since the first available (rfkill0) is the
+# one from the HCI driver in the kernel (net/bluetooth/hci_core.c).
+PRODUCT_PROPERTY_OVERRIDES += \
+	ro.bt.rfkill.state=/sys/class/rfkill/rfkill1/state
 
 BOARD_CUSTOM_BT_CONFIG := device/boundary/nit6xlite/libbt_vnd_nit6xlite.conf
-BOARD_WLAN_DEVICE_REV  := bcm4330_b2
-WIFI_BAND              := 802_11_ABG
-$(call inherit-product-if-exists, hardware/broadcom/wlan/bcmdhd/firmware/bcm4330/device-bcm.mk)
 
 # Misc packages
 PRODUCT_PACKAGES += \

--- a/nit6xlite/nit6xlite.mk
+++ b/nit6xlite/nit6xlite.mk
@@ -117,6 +117,16 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
 	ro.sys.sdcardfs=0
 
+PRODUCT_PACKAGES += \
+    start-ssh \
+    sshd_config \
+    ssh-keygen \
+    sshd \
+    scp \
+    sftp \
+    ssh \
+    libssh
+
 DEVICE_PACKAGE_OVERLAYS := \
 	device/boundary/nit6xlite/overlay \
 	device/boundary/common/overlay

--- a/nit6xlite/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/nit6xlite/overlay/frameworks/base/core/res/res/values/config.xml
@@ -22,4 +22,5 @@
 <resources>
     <!-- Boolean indicating whether the wifi chipset has dual frequency band support -->
     <bool translatable="false" name="config_wifi_dual_band_support">false</bool>
+    <bool name="config_disableUsbPermissionDialogs">true</bool>
 </resources>

--- a/nit6xlite/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/nit6xlite/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<resources>
+    <dimen name="status_bar_height">0dp</dimen>
+    <!-- Height of the bottom navigation / system bar. -->
+</resources>

--- a/nit6xlite/ueventd.freescale.rc
+++ b/nit6xlite/ueventd.freescale.rc
@@ -1,6 +1,5 @@
 /dev/pmem_gpu             0660   system     graphics
 /dev/ttymxc*              0666   system     system
-/dev/ttymxc2              0660   bluetooth  bluetooth
 /dev/snd/*                0664   system     audio
 /dev/ttyUSB*              0640   radio      radio
 /dev/ttyACM*              0640   radio      radio

--- a/nit6xlite/ueventd.freescale.rc
+++ b/nit6xlite/ueventd.freescale.rc
@@ -43,3 +43,5 @@
 /sys/devices/soc0/fb* mode 0660 system graphics
 /sys/devices/soc0/soc/soc:busfreq* enable 0660 system system
 /sys/devices/system/cpu/cpu* online 0664 root system
+
+/sys/devices/soc0/leds* brightness 0666 system system

--- a/nitrogen6x/wifi_config.mk
+++ b/nitrogen6x/wifi_config.mk
@@ -1,2 +1,2 @@
 # Select WiFi/BT chip here, either TI or BCM or QCA
-BOARD_WLAN_VENDOR := TI
+BOARD_WLAN_VENDOR := QCA

--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -34,3 +34,9 @@ allow platform_app mediadrmserver_exec:file getattr;
 allow platform_app mediaextractor_exec:file getattr;
 allow platform_app profman_exec:file getattr;
 allow platform_app system_app_data_file:dir getattr;
+
+allow platform_app sysfs_leds:dir search;
+allow platform_app tty_device:chr_file write;
+allow platform_app sysfs_leds:lnk_file { read write };
+
+allow platform_app sysfs:file { read write open getattr };


### PR DESCRIPTION
Changes to support different features on the Access Control board:
- change wifi chip support using the Qualcomm HAL,
- build and include the Access board device tree,
- implement different SELinux and ueventd rules,
- implement some customization (e.g. hide the status bar).