### PR TITLE
nitrogen8mm: Add missing bootloaders

### DIFF
--- a/nitrogen8mm/UbootKernelBoardConfig.mk
+++ b/nitrogen8mm/UbootKernelBoardConfig.mk
@@ -1,9 +1,17 @@
 TARGET_BOOTLOADER_POSTFIX := bin
 UBOOT_POST_PROCESS := true
 
-TARGET_BOOTLOADER_CONFIG := imx8mm:nitrogen8mm_2g_defconfig
+TARGET_BOOTLOADER_CONFIG := imx8mm:nitrogen8mm_2g_defconfig \
+                            imx8mm:nitrogen8mm_2gr0_defconfig \
+                            imx8mm:nitrogen8mm_4g_defconfig \
+                            imx8mm:nitrogen8mm_rev2_2g_defconfig \
+                            imx8mm:nitrogen8mm_rev2_4g_defconfig \
+                            imx8mm:nitrogen8mm_som_1gr0_defconfig \
+                            imx8mm:nitrogen8mm_som_2g_defconfig \
+                            imx8mm:nitrogen8mm_som_2gr0_defconfig \
+                            imx8mm:nitrogen8mm_som_4g_defconfig
 
-TARGET_BOOTLOADER_PREBUILT := nitrogen8mm_2g nitrogen8mm_4g nitrogen8mm_rev2_2g nitrogen8mm_som_2g nitrogen8mm_som_4g
+TARGET_BOOTLOADER_PREBUILT := nitrogen8mm_2g nitrogen8mm_2gr0 nitrogen8mm_4g nitrogen8mm_rev2_2g nitrogen8mm_rev2_4g nitrogen8mm_som_1gr0 nitrogen8mm_som_2g nitrogen8mm_som_2gr0 nitrogen8mm_som_4g
 
 TARGET_KERNEL_DEFCONFIG := boundary_android_defconfig
 


### PR DESCRIPTION
Some existing bootloaders are missing on board definition.

Signed-off-by: Adrien Grassein <adrien.grassein@gmail.com>