### PR TITLE
common: scripts: Fix flashing script

### DIFF
--- a/scripts/flash_fastboot.bat
+++ b/scripts/flash_fastboot.bat
@@ -16,6 +16,11 @@ IF %ERRORLEVEL% NEQ 0 (
 	ECHO Failed to flash gpt.img
 	GOTO:eof
 )
+fastboot.exe reboot bootloader
+IF %ERRORLEVEL% NEQ 0 (
+	ECHO Failed to reboot in bootloader mode
+	GOTO:eof
+)
 fastboot.exe flash preboot %OUT%\preboot.img
 IF %ERRORLEVEL% NEQ 0 (
 	ECHO Failed to flash preboot.img
@@ -61,5 +66,5 @@ IF %ERRORLEVEL% NEQ 0 (
 	ECHO Failed to erase userdata
 	GOTO:eof
 )
-fastboot.exe continue
+fastboot.exe reboot
 ECHO Flashing successful!

--- a/scripts/flash_fastboot.sh
+++ b/scripts/flash_fastboot.sh
@@ -54,6 +54,8 @@ fi
 
 fastboot flash gpt $OUT/$gpt
 if ! [ $? -eq 0 ] ; then echo "Failed to flash gpt.img"; exit 1; fi
+fastboot reboot bootloader
+if ! [ $? -eq 0 ] ; then echo "Failed to rebot into bootloader mode"; exit 1; fi
 fastboot flash preboot $OUT/preboot.img
 if ! [ $? -eq 0 ] ; then echo "Failed to flash preboot.img"; exit 1; fi
 fastboot flash dtbo $OUT/dtbo.img
@@ -74,4 +76,4 @@ if ! [ ${skip_userdata} -eq 1 ] ; then
 	fastboot erase userdata
 	if ! [ $? -eq 0 ] ; then echo "Failed to erase userdata"; exit 1; fi
 fi
-fastboot continue
+fastboot reboot


### PR DESCRIPTION
Fixed to potential errors in flash script:
 - It's recommanded to reboot after flashing gpt.
If you don't reboot after flashing it, it will not
be taken in account

 - It's better to reboot after flashing instead of
continuing because, if you interrupted the boot for
flahsing, the board will not start
(and crash after pressing enter in the u-boot shell).



Signed-off-by: Adrien Grassein <adrien.grassein@gmail.com>