### PR TITLE
common: u-boot image signature

### DIFF
--- a/common/build/uboot.mk
+++ b/common/build/uboot.mk
@@ -47,6 +47,13 @@ $(error If TARGET_UBOOT_ENV is set TARGET_UBOOT_ENV_SIZE must also be set. See\
 endif
 endif
 
+# Check if we can sign u-boot image.
+# For this CST_BIN, SIGN_KEY, IMG_KEY and SRK_TABLE must all be defined.
+ifneq ($(and $(CST_BIN),$(SIGN_KEY),$(IMG_KEY),$(SRK_TABLE)),)
+$(info u-boot will be signed)
+UBOOT_SIGN := true
+endif
+
 # TARGET_UBOOT_BUILD_TARGET may be assigned in target BoardConfig.mk.
 TARGET_UBOOT_BUILD_TARGET ?= u-boot.imx
 
@@ -144,6 +151,13 @@ $(UBOOT_BIN): $(UBOOTENVSH) | $(UBOOT_COLLECTION) $(UBOOT_OUT)
 		install -D $(UBOOT_COLLECTION)/flash.bin $(UBOOT_BIN); \
 		UBOOT_BD_NAME=`echo u-boot.$$UBOOT_CONFIG | sed 's/_defconfig//'`; \
 		install -D $(UBOOT_COLLECTION)/flash.bin $(PRODUCT_OUT)/preboot/$$UBOOT_BD_NAME; \
+		if [ "$(UBOOT_SIGN)" = "true" ]; then \
+			echo "Signing $$UBOOT_BD_NAME"; \
+			cd $(UBOOT_OUT); \
+			$(ANDROID_BUILD_TOP)/$(UBOOT_IMX_PATH)/uboot-imx/sign_hab_imx8m.sh; \
+			cd -; \
+			install -D $(UBOOT_OUT)/signed_flash.bin $(PRODUCT_OUT)/preboot/$$UBOOT_BD_NAME; \
+		fi; \
 	done
 
 .PHONY: bootloader $(UBOOT_BIN) $(UBOOTENVSH)


### PR DESCRIPTION
Check if we have env variables needed to sign u-boot images.
If it is the case, sign each image and install them in preboot
directory.

Testing done: $ ./imx-make bootloader
There are only not signed images in out/target/product/*/preboot/u-boot.*

$ export CST_BIN=~/release/linux64/bin/cst
$ export SIGN_KEY=~/release/crts/CSF1_1_sha256_4096_65537_v3_usr_crt.pem
$ export IMG_KEY=~/release/crts/IMG1_1_sha256_4096_65537_v3_usr_crt.pem
$ export SRK_TABLE=~/release/crts/SRK_1_2_3_4_table.bin
$ ./imx-make bootloader
There are signed images in out/target/product/*/preboot/signed_u-boot.*

Signed-off-by: Jeremie Finiel jeremie.finiel@pulse-origin.com